### PR TITLE
bump JDK version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: 8
+          java-version: 11
           java-package: jdk
       - name: "🧰 Setup Android SDK"
         uses: android-actions/setup-android@v2


### PR DESCRIPTION
the CI is failing due to version conflict. Hence, the Code coverage isn't being generated / uploaded

https://github.com/Crazy-Marvin/VacationDays/runs/5524498484?check_suite_focus=true#step:7:32