### PR TITLE
integrate JaCoCo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,19 @@ jobs:
       - name: "🏗 Build"
         run: ./gradlew assembleDebug
       - name: "🧪 Code coverage"
-        run: ./gradlew test
-      - name: "📤 Upload code coverage"
-        uses: codecov/codecov-action@v2
+        run: ./gradlew connectedCheck
+      - name:  "🧪 Generate report"
+        uses: actions/upload-artifact@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: report 
+          path: app/build/reports/coverage/debug
+      - name: "🧪 Download Test Reports Folder"
+        uses: actions/download-artifact@v3
+        with:
+          name: report
+          path: app/build/reports/coverage/debug
+      - name: "📤 Upload Test Report"
+        run:  bash <(curl -s https://codecov.io/bash) -f "app/build/reports/coverage/debug/report.xml"
       - name: "🧪 Android LINT"
         run: ./gradlew lint
       - name: "🧪 Unit test"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,25 @@
 plugins {
     id 'com.android.application'
+    id 'jacoco'
+}
+
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+
+    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
+    def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter)
+    def mainSrc = "${project.projectDir}/src/main/java"
+
+    sourceDirectories.setFrom(files([mainSrc]))
+    classDirectories.setFrom(files([debugTree]))
+    executionData.setFrom(fileTree(dir: "$buildDir", includes: [
+            "jacoco/testDebugUnitTest.exec",
+            "outputs/code-coverage/connected/*coverage.ec"
+    ]))
 }
 
 android {
@@ -16,7 +36,19 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    testOptions {
+        unitTests.all {
+            jacoco {
+                includeNoLocationClasses = true
+            }
+        }
+        unitTests.returnDefaultValues = true
+    }
+
     buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    ext.jacocoVersion = '0.8.4'
     repositories {
         google()
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.1.2'
-
+        classpath "org.jacoco:org.jacoco.core:$jacocoVersion"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+{
+    "fixes": [
+         - "debugAndroidTest/::app/src/test/java/"
+    ],
+    "codecov": {
+        "disable_default_path_fixes": true
+    }
+}


### PR DESCRIPTION
This PR installs JaCoCo plugin for gradle.

JaCoCo generates the code coverage, which is then uploaded to CodeCov