### PR TITLE
Fix date display for vacations with 1 day

### DIFF
--- a/app/src/main/java/rocks/poopjournal/vacationdays/SubItemAdapter.java
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/SubItemAdapter.java
@@ -50,14 +50,10 @@ public class SubItemAdapter extends RecyclerView.Adapter<SubItemAdapter.SubItemV
         db.updateHabitsIdsForDeletion(subItem.getSubItemTitle(),subItem.getMonthyear(),updatedid);
         db.show_data();
         if(subItem.getStart().equals(subItem.getEnd())){
-            subItemViewHolder.startdate.setVisibility(View.INVISIBLE);
-            subItemViewHolder.to.setText(subItem.getStart());
-            subItemViewHolder.enddate.setVisibility(View.INVISIBLE);
+            subItemViewHolder.dateRange.setText(subItem.getStart());
         }
         else{
-            subItemViewHolder.startdate.setText(subItem.getStart());
-            subItemViewHolder.to.setBackgroundResource(R.drawable.arrow_down);
-            subItemViewHolder.enddate.setText(subItem.getEnd());
+            subItemViewHolder.dateRange.setText(con.getString(R.string.date_range, subItem.getStart(), subItem.getEnd()));
         }
 
         subItemViewHolder.img.setOnClickListener(new View.OnClickListener() {
@@ -98,16 +94,14 @@ public class SubItemAdapter extends RecyclerView.Adapter<SubItemAdapter.SubItemV
         return subItemList.size();
     }
 
-    class SubItemViewHolder extends RecyclerView.ViewHolder {
-        TextView tvSubItemTitle, startdate, to, enddate;
+    static class SubItemViewHolder extends RecyclerView.ViewHolder {
+        TextView tvSubItemTitle, dateRange;
         ImageView img;
 
         SubItemViewHolder(View itemView) {
             super(itemView);
             tvSubItemTitle = itemView.findViewById(R.id.tv_sub_item_title);
-            startdate = itemView.findViewById(R.id.startdate);
-            to = itemView.findViewById(R.id.to);
-            enddate = itemView.findViewById(R.id.enddate);
+            dateRange = itemView.findViewById(R.id.date_range);
             img=itemView.findViewById(R.id.btndel);
         }
     }

--- a/app/src/main/res/layout/layout_sub_item.xml
+++ b/app/src/main/res/layout/layout_sub_item.xml
@@ -13,40 +13,13 @@
         android:layout_marginRight="5dp"
         >
 
-        <LinearLayout
-            android:id="@+id/lin"
-            android:layout_width="wrap_content"
+        <TextView
+            android:id="@+id/date_range"
+            android:layout_width="30dp"
             android:layout_height="60dp"
-            android:orientation="vertical"
-            android:layout_marginTop="12dp">
-
-            <TextView
-                android:id="@+id/startdate"
-                android:layout_width="20dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginLeft="2dp"
-                android:background="@android:color/transparent"
-                android:textColor="@color/subitem_text"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/to"
-                android:layout_width="15dp"
-                android:layout_height="15dp"
-                android:layout_gravity="center"
-                android:background="@android:color/transparent"
-                android:textColor="@color/subitem_text" />
-
-            <TextView
-                android:id="@+id/enddate"
-                android:layout_width="20dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:background="@android:color/transparent"
-                android:textColor="@color/subitem_text"
-                android:textSize="14sp" />
-        </LinearLayout>
+            android:textColor="@color/subitem_text"
+            android:gravity="center"
+            android:layout_gravity="center"/>
 
 
         <androidx.cardview.widget.CardView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="addHoliday">Add Holiday Title</string>
     <string name="save">Save</string>
     <string name="ok">OK</string>
+    <string name="date_range">%s\n↓\n%s</string>
     <string name="followsys">Follow System</string>
     <string name="light">Light</string>
     <string name="dark">Dark</string>


### PR DESCRIPTION
Hi. I have successfully fixed the date display for vacations with a single day (as I mentioned in #75).
For example, this is 28/9 before the fix:
![Screenshot_20220924-155229165](https://user-images.githubusercontent.com/95969852/192089721-9ef78e21-4bf0-4f8c-9daf-a28a49d6fd64.jpg)
After the fix:
![Screenshot_20220924-155505813](https://user-images.githubusercontent.com/95969852/192089743-dfe5c414-295e-41b2-8d1a-6ef0708bd304.jpg)
I hope you can look at it... preferably quickly... I have other improvements to propose in the future...