### PR TITLE
Exclude weekends and Sort vacations

### DIFF
--- a/app/src/main/java/rocks/poopjournal/vacationdays/domain/model/VacData.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/domain/model/VacData.kt
@@ -1,0 +1,14 @@
+package rocks.poopjournal.vacationdays.domain.model
+
+import rocks.poopjournal.vacationdays.data.VacationData
+
+sealed class VacData {
+    data object Empty : VacData()
+
+    data class Success(
+        val vacations: List<VacationData>,
+        val vacationDays: Int,
+        val sickDays: Int,
+        val vacationsNumber: Int,
+    ) : VacData()
+}

--- a/app/src/main/java/rocks/poopjournal/vacationdays/domain/service/ThemeRepositoryImpl.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/domain/service/ThemeRepositoryImpl.kt
@@ -2,63 +2,40 @@ package rocks.poopjournal.vacationdays.domain.service
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.core.content.edit
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.flow.MutableStateFlow
 import rocks.poopjournal.vacationdays.presentation.ui.utils.AppTheme
+import rocks.poopjournal.vacationdays.presentation.ui.utils.BooleanPreferenceDelegate
+import rocks.poopjournal.vacationdays.presentation.ui.utils.PreferenceConverter
 import rocks.poopjournal.vacationdays.presentation.ui.utils.ThemeSetting
+import rocks.poopjournal.vacationdays.presentation.ui.utils.TypedIntPreferenceDelegate
 import javax.inject.Inject
-import kotlin.properties.ReadWriteProperty
-import kotlin.reflect.KProperty
 
 class ThemeSettingImpl @Inject constructor(
     @ApplicationContext context: Context,
 ) : ThemeSetting {
 
-    // Existing theme-related code
-    override var theme: AppTheme by AppThemePreferenceDelegate("app_theme", AppTheme.LIGHT)
-    override val themeFlow: MutableStateFlow<AppTheme>
     private val preferences: SharedPreferences =
         context.getSharedPreferences("sample_theme", Context.MODE_PRIVATE)
 
-    // New property for the boolean (e.g., feature enable/disable flag)
-    override var isFeatureEnabled: Boolean by BooleanPreferenceDelegate("is_feature_enabled", false)
-    val featureEnabledFlow: MutableStateFlow<Boolean>
+    private val appThemeDelegate =
+        TypedIntPreferenceDelegate(preferences, "app_theme", AppTheme.LIGHT, AppThemeConverter)
+    override var theme: AppTheme by appThemeDelegate
+    override val themeFlow = appThemeDelegate.flow
 
-    init {
-        themeFlow = MutableStateFlow(theme)
-        featureEnabledFlow = MutableStateFlow(isFeatureEnabled)
-    }
+    // sick days tracking
+    private val featureEnabledDelegate =
+        BooleanPreferenceDelegate(preferences, "is_feature_enabled", false)
+    override var isFeatureEnabled: Boolean by featureEnabledDelegate
+    val featureEnabledFlow = featureEnabledDelegate.flow
 
-    // Delegate for saving and retrieving the theme
-    inner class AppThemePreferenceDelegate(
-        private val name: String,
-        private val default: AppTheme,
-    ) : ReadWriteProperty<Any, AppTheme> {
-        override fun getValue(thisRef: Any, property: KProperty<*>): AppTheme =
-            AppTheme.fromOrdinal(preferences.getInt(name, default.ordinal))
+    // weekend exclusion
+    private val isExcludeWeekendsDelegate =
+        BooleanPreferenceDelegate(preferences, "is_exclude_weekends", false)
+    override var isExcludeWeekendsEnabled: Boolean by isExcludeWeekendsDelegate
+    override val isExcludeWeekendsFlow = isExcludeWeekendsDelegate.flow
 
-        override fun setValue(thisRef: Any, property: KProperty<*>, value: AppTheme) {
-            themeFlow.value = value
-            preferences.edit {
-                putInt(name, value.ordinal)
-            }
-        }
-    }
-
-    // Delegate for saving and retrieving the boolean feature flag
-    inner class BooleanPreferenceDelegate(
-        private val name: String,
-        private val default: Boolean,
-    ) : ReadWriteProperty<Any, Boolean> {
-        override fun getValue(thisRef: Any, property: KProperty<*>): Boolean =
-            preferences.getBoolean(name, default)
-
-        override fun setValue(thisRef: Any, property: KProperty<*>, value: Boolean) {
-            featureEnabledFlow.value = value
-            preferences.edit {
-                putBoolean(name, value)
-            }
-        }
+    private object AppThemeConverter : PreferenceConverter<AppTheme, Int> {
+        override fun serialize(value: AppTheme): Int = value.ordinal
+        override fun deserialize(value: Int): AppTheme = AppTheme.fromOrdinal(value)
     }
 }

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/home/HomeScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -60,10 +59,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.launch
 import rocks.poopjournal.vacationdays.R
 import rocks.poopjournal.vacationdays.data.VacationData
+import rocks.poopjournal.vacationdays.domain.model.VacData
 import rocks.poopjournal.vacationdays.presentation.component.CalenderView
 import rocks.poopjournal.vacationdays.presentation.component.CustomTab
 import rocks.poopjournal.vacationdays.presentation.navigation.About_Screen
@@ -74,17 +75,35 @@ import java.time.LocalDate
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 
-@OptIn(ExperimentalMaterialApi::class)
-@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun HomeScreen(viewModel: HomeViewModel = hiltViewModel(), navHostController: NavHostController) {
-    val vacation by viewModel.holidays.collectAsState()
-    val (selectedTab, setSelectedTab) = remember { mutableIntStateOf(0) }
-    val vacationDays by viewModel.vacationDays.collectAsState()
-    val sickDays by viewModel.sickDays.collectAsState()
-    val totalHolidays by viewModel.totalHolidays.collectAsState()
-    val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+
+    val (selectedTab, setSelectedTab) = remember { mutableIntStateOf(0) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val data by viewModel.dataFlow.collectAsStateWithLifecycle(VacData.Empty)
+
+    val vacation = when (val _data = data) {
+        is VacData.Empty -> emptyList()
+        is VacData.Success -> _data.vacations
+    }
+
+    val vacationDays = when (val _data = data) {
+        is VacData.Empty -> 0
+        is VacData.Success -> _data.vacationDays
+    }
+
+    val sickDays = when (val _data = data) {
+        is VacData.Empty -> 0
+        is VacData.Success -> _data.sickDays
+    }
+
+    val totalHolidays = when (val _data = data) {
+        is VacData.Empty -> 0
+        is VacData.Success -> _data.vacationsNumber
+    }
+
     Scaffold(
         floatingActionButton = {
             FloatingActionButton(

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/home/HomeViewModel.kt
@@ -1,95 +1,95 @@
 package rocks.poopjournal.vacationdays.presentation.screen.home
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import rocks.poopjournal.vacationdays.data.VacationData
+import rocks.poopjournal.vacationdays.domain.model.VacData
 import rocks.poopjournal.vacationdays.domain.repo.VacationNumberRepository
 import rocks.poopjournal.vacationdays.domain.repo.VacationRepository
 import rocks.poopjournal.vacationdays.presentation.ui.utils.ThemeSetting
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 
-@RequiresApi(Build.VERSION_CODES.O)
+
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val vacationRepository: VacationRepository,
-    private val vacationNumberRepository: VacationNumberRepository
+    private val vacationNumberRepository: VacationNumberRepository,
+    val themeSetting: ThemeSetting
 ) : ViewModel() {
 
-    @Inject
-    lateinit var themeSetting: ThemeSetting
+    private val formatter = DateTimeFormatter.ofPattern("d/MM/yyyy") // Match the saved format
 
-    private val _holidays = MutableStateFlow<List<VacationData>>(emptyList())
-    val holidays: StateFlow<List<VacationData>> = _holidays
+    val dataFlow: SharedFlow<VacData> =
+        combine(
+            vacationRepository.getAllData(),
+            themeSetting.isExcludeWeekendsFlow,
+        ) { data, isExcludeHolidays ->
 
-    private val _vacationDays = MutableStateFlow(0)
-    val vacationDays: StateFlow<Int> = _vacationDays
+            val vacationDaysCount = data
+                .filter { it.category == "Vacation" }
+                .sumOf { calculateDaysBetween(it.startDate, it.endDate, isExcludeHolidays) }
 
-    private val _sickDays = MutableStateFlow(0)
-    val sickDays: StateFlow<Int> = _sickDays
+            val sickDaysCount = data
+                .filter { it.category == "Sick" }
+                .sumOf { calculateDaysBetween(it.startDate, it.endDate, isExcludeHolidays) }
 
-    private val _totalHolidays = MutableStateFlow(0)
-    val totalHolidays: StateFlow<Int> = _totalHolidays
+            val currentYear = LocalDate.now().year.toString()
+            val vacationNumber = vacationNumberRepository.getVacationNumberForYear(currentYear)
+            val maxVacationNumber = maxOf(vacationNumber - vacationDaysCount, 0)
 
-    init {
-        fetchHolidays()
-        fetchVacationNumber()
-
-    }
-
-    @RequiresApi(Build.VERSION_CODES.O)
-    private fun fetchHolidays() {
-        viewModelScope.launch {
-            vacationRepository.getAllData().collect { data ->
-                _holidays.value = data
-
-                val vacationDaysCount = data
-                    .filter { it.category == "Vacation" }
-                    .sumOf { calculateDaysBetween(it.startDate, it.endDate) }
-
-                val sickDaysCount = data
-                    .filter { it.category == "Sick" }
-                    .sumOf { calculateDaysBetween(it.startDate, it.endDate) }
-
-                _vacationDays.value = vacationDaysCount
-                _sickDays.value = sickDaysCount
-
-                fetchVacationNumber()
-            }
+            VacData.Success(
+                vacations = data.sortedBy { LocalDate.parse(it.startDate, formatter) },
+                vacationDays = vacationDaysCount,
+                sickDays = sickDaysCount,
+                vacationsNumber = maxVacationNumber
+            )
         }
-    }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = VacData.Empty
+            )
 
-    @RequiresApi(Build.VERSION_CODES.O)
-    private fun calculateDaysBetween(startDate: String, endDate: String?): Int {
-        val formatter = DateTimeFormatter.ofPattern("d/MM/yyyy") // Match the saved format
+
+    private fun calculateDaysBetween(
+        startDate: String,
+        endDate: String?,
+        excludeWeekends: Boolean = false
+    ): Int {
         val start = LocalDate.parse(startDate, formatter)
 
         return if (endDate.isNullOrEmpty()) {
             1 // If no end date, count it as 1 day
         } else {
             val end = LocalDate.parse(endDate, formatter)
-            ChronoUnit.DAYS.between(start, end).toInt() + 1 // Include both start and end
+            val days = ChronoUnit.DAYS.between(start, end).toInt()
+
+            if (excludeWeekends) {
+                val startW = start.dayOfWeek
+                val endW = end.dayOfWeek
+                val daysWithoutWeekends = days - 2 * ((days + startW.value) / 7)
+
+                (daysWithoutWeekends
+                        + (if (startW == DayOfWeek.SUNDAY) 1 else 0)
+                        + (if (endW == DayOfWeek.SUNDAY) 1 else 0)
+                        + 1 // include start and end
+                        )
+            } else
+                days + 1 // Include both start and end
         }
     }
 
-    private fun fetchVacationNumber() {
-        viewModelScope.launch {
-            val currentYear = LocalDate.now().year.toString()
-            val vacationNumber = vacationNumberRepository.getVacationNumberForYear(currentYear)
-
-            _totalHolidays.value = maxOf(vacationNumber - _vacationDays.value, 0)
-        }
-    }
-
-    fun deleteVacation(vacationData: VacationData){
+    fun deleteVacation(vacationData: VacationData) {
         viewModelScope.launch {
             vacationRepository.deleteData(vacationData)
         }

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/settings/SettingScreen.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/settings/SettingScreen.kt
@@ -62,9 +62,11 @@ fun SettingScreen(
     val vacationNumber = vacationForCurrentYear?.numberOfVacation ?: 0
 
     var localFeatureEnabled by remember { mutableStateOf(false) }
+    var localExcludeWeekendsEnabled by remember { mutableStateOf(false) }
 
     LaunchedEffect(localFeatureEnabled) {
         localFeatureEnabled = viewModel.themeSetting.isFeatureEnabled
+        localExcludeWeekendsEnabled = viewModel.themeSetting.isExcludeWeekendsEnabled
     }
 
     Column(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
@@ -130,6 +132,34 @@ fun SettingScreen(
                         localFeatureEnabled = newState
 
                         viewModel.themeSetting.isFeatureEnabled = newState
+                    },
+                    colors = SwitchDefaults.colors(
+                        checkedIconColor = MaterialTheme.colorScheme.surface,
+                        checkedTrackColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.3f),
+                        checkedThumbColor = MaterialTheme.colorScheme.surface
+                    ),
+                )
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp)
+                    .height(48.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(id = R.string.exclude_weekends),
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Bold,)
+
+                Switch(
+                    checked = localExcludeWeekendsEnabled,
+                    onCheckedChange = { newState ->
+                        localExcludeWeekendsEnabled = newState
+
+                        viewModel.themeSetting.isExcludeWeekendsEnabled = newState
                     },
                     colors = SwitchDefaults.colors(
                         checkedIconColor = MaterialTheme.colorScheme.surface,

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/ui/utils/BooleanPreferenceDelegate.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/ui/utils/BooleanPreferenceDelegate.kt
@@ -1,0 +1,28 @@
+package rocks.poopjournal.vacationdays.presentation.ui.utils
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlin.reflect.KProperty
+import androidx.core.content.edit
+import kotlin.properties.ReadWriteProperty
+
+class BooleanPreferenceDelegate(
+    private val prefs: SharedPreferences,
+    private val key: String,
+    private val defaultValue: Boolean,
+): ReadWriteProperty<Any, Boolean> {
+    private val _stateFlow = MutableStateFlow(getValueFromPrefs())
+    val flow: StateFlow<Boolean> = _stateFlow
+
+    private fun getValueFromPrefs(): Boolean = prefs.getBoolean(key, defaultValue)
+
+    override fun getValue(thisRef: Any, property: KProperty<*>): Boolean {
+        return _stateFlow.value
+    }
+
+    override fun setValue(thisRef: Any, property: KProperty<*>, value: Boolean) {
+        prefs.edit { putBoolean(key, value) }
+        _stateFlow.value = value
+    }
+}

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/ui/utils/PreferenceConverter.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/ui/utils/PreferenceConverter.kt
@@ -1,0 +1,6 @@
+package rocks.poopjournal.vacationdays.presentation.ui.utils
+
+interface PreferenceConverter<T, R> {
+    fun serialize(value: T): R
+    fun deserialize(value: R): T
+}

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/ui/utils/ThemeModes.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/ui/utils/ThemeModes.kt
@@ -25,4 +25,6 @@ interface ThemeSetting {
     val themeFlow : StateFlow<AppTheme>
     var theme : AppTheme
     var isFeatureEnabled: Boolean
+    var isExcludeWeekendsEnabled: Boolean
+    val isExcludeWeekendsFlow: StateFlow<Boolean>
 }

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/ui/utils/TypedIntPreferenceDelegate.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/ui/utils/TypedIntPreferenceDelegate.kt
@@ -1,0 +1,32 @@
+package rocks.poopjournal.vacationdays.presentation.ui.utils
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlin.reflect.KProperty
+import androidx.core.content.edit
+import kotlin.properties.ReadWriteProperty
+
+class TypedIntPreferenceDelegate<T>(
+    private val prefs: SharedPreferences,
+    private val key: String,
+    private val defaultValue: T,
+    private val converter: PreferenceConverter<T, Int>
+): ReadWriteProperty<Any, T> {
+    private val _stateFlow = MutableStateFlow(getValueFromPrefs())
+    val flow: StateFlow<T> = _stateFlow
+
+    private fun getValueFromPrefs(): T {
+        val stored = prefs.getInt(key, -1)
+        return if (stored != -1) converter.deserialize(stored) else defaultValue
+    }
+
+    override fun getValue(thisRef: Any, property: KProperty<*>): T {
+        return _stateFlow.value
+    }
+
+    override fun setValue(thisRef: Any, property: KProperty<*>, value: T) {
+        prefs.edit { putInt(key, converter.serialize(value)) }
+        _stateFlow.value = value
+    }
+}

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/ui/utils/TypedStringPreferenceDelegate.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/ui/utils/TypedStringPreferenceDelegate.kt
@@ -1,0 +1,32 @@
+package rocks.poopjournal.vacationdays.presentation.ui.utils
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlin.reflect.KProperty
+import androidx.core.content.edit
+import kotlin.properties.ReadWriteProperty
+
+class TypedStringPreferenceDelegate<T>(
+    private val prefs: SharedPreferences,
+    private val key: String,
+    private val defaultValue: T,
+    private val converter: PreferenceConverter<T, String>
+): ReadWriteProperty<Any, T> {
+    private val _stateFlow = MutableStateFlow(getValueFromPrefs())
+    val flow: StateFlow<T> = _stateFlow
+
+    private fun getValueFromPrefs(): T {
+        val stored = prefs.getString(key, null)
+        return if (stored != null) converter.deserialize(stored) else defaultValue
+    }
+
+    override fun getValue(thisRef: Any, property: KProperty<*>): T {
+        return _stateFlow.value
+    }
+
+    override fun setValue(thisRef: Any, property: KProperty<*>, value: T) {
+        prefs.edit { putString(key, converter.serialize(value)) }
+        _stateFlow.value = value
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="title_activity_main2" translatable="false">MainActivity2</string>
     <string name="empty_text">No Vacation Added</string>
     <string name="track">Track Sick Days</string>
+    <string name="exclude_weekends">Exclude weekends</string>
     <string name="backupMessage">Backup Successful</string>
     <string name="vacation_days">No. of Vacation Days</string>
     <string name="junit">JUnit</string>


### PR DESCRIPTION
PR attempts to solve:
- (partially) #266  - by adding "Exclude Weekends" setting
- #202 - by sorting vacations by parsed start date

Also includes:
- refactor of HomeViewModel combining various flows into one `VacData` flow
- slight refactor of `ThemeSettingImpl` simplifying adding new settings
