### PR TITLE
Settings screen refactor +  Calendar weekdays selection

### DIFF
--- a/app/src/main/java/rocks/poopjournal/vacationdays/domain/service/ThemeRepositoryImpl.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/domain/service/ThemeRepositoryImpl.kt
@@ -3,6 +3,7 @@ package rocks.poopjournal.vacationdays.domain.service
 import android.content.Context
 import android.content.SharedPreferences
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.StateFlow
 import rocks.poopjournal.vacationdays.presentation.ui.utils.AppTheme
 import rocks.poopjournal.vacationdays.presentation.ui.utils.BooleanPreferenceDelegate
 import rocks.poopjournal.vacationdays.presentation.ui.utils.PreferenceConverter
@@ -33,6 +34,13 @@ class ThemeSettingImpl @Inject constructor(
         BooleanPreferenceDelegate(preferences, "is_exclude_weekends", false)
     override var isExcludeWeekendsEnabled: Boolean by isExcludeWeekendsDelegate
     override val isExcludeWeekendsFlow = isExcludeWeekendsDelegate.flow
+
+    // weekdays header
+    private val isShowWeekdaysHeaderDelegate =
+        BooleanPreferenceDelegate(preferences, "is_show_weekdays_header", false)
+    override var isShowWeekDaysHeaderEnabled: Boolean by isShowWeekdaysHeaderDelegate
+    override val isShowWeekDaysHeaderFlow = isShowWeekdaysHeaderDelegate.flow
+
 
     private object AppThemeConverter : PreferenceConverter<AppTheme, Int> {
         override fun serialize(value: AppTheme): Int = value.ordinal

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
@@ -212,7 +212,11 @@ private fun Day(
 
     val backgroundColor = when {
         isRangeSelection && (isSelectedStart || isSelectedEnd) -> MaterialTheme.colorScheme.primary // Highlight selection only in range mode
-        isRangeSelection && isInRange -> MaterialTheme.colorScheme.primary.copy(alpha = 0.1f) // Highlight range
+        else -> Color.Transparent
+    }
+
+    val secondaryBackgroundColor = when {
+        isRangeSelection && (isInRange || (isSelectedStart || isSelectedEnd)) -> MaterialTheme.colorScheme.primary.copy(alpha = 0.1f) // Highlight range
         else -> Color.Transparent
     }
 
@@ -233,9 +237,7 @@ private fun Day(
             .background(
                 color = backgroundColor,
                 shape = when {
-                    (isSelectedStart && selection.endDate == null) -> CircleShape
-                    isSelectedStart -> RoundedCornerShape(50, 0, 0, 50)
-                    isSelectedEnd -> RoundedCornerShape(0, 50, 50, 0)
+                    isSelectedStart || isSelectedEnd -> CircleShape
                     else -> RectangleShape
                 }
             )
@@ -246,15 +248,28 @@ private fun Day(
             ),
         contentAlignment = Alignment.Center,
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(
-                text = day.date.dayOfMonth.toString(),
-                color = textColor,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Bold,
-            )
-            if (!isRangeSelection) {
-                Text(text = ".", fontWeight = FontWeight.Bold, color = dotColor)
+        Box (
+            modifier = Modifier
+                .background(color = secondaryBackgroundColor,
+                    shape= when {
+                        (isSelectedStart && selection.endDate == null) -> CircleShape
+                        isSelectedStart -> RoundedCornerShape(50, 0, 0, 50)
+                        isSelectedEnd -> RoundedCornerShape(0, 50, 50, 0)
+                        else -> RectangleShape
+                    })
+                .matchParentSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = day.date.dayOfMonth.toString(),
+                    color = textColor,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+                if (!isRangeSelection) {
+                    Text(text = ".", fontWeight = FontWeight.Bold, color = dotColor)
+                }
             }
         }
     }

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
@@ -67,7 +67,8 @@ import java.util.Locale
 fun CalenderView(
     dateSelected: (startDate: LocalDate, endDate: LocalDate?) -> Unit = { _, _ -> },
     isRangeSelection: Boolean = false,
-    holidays: List<VacationData> = emptyList()
+    holidays: List<VacationData> = emptyList(),
+    showWeekDaysHeader: Boolean = false,
 ) {
     val currentYear = YearMonth.now().year
     var selectedYear by remember { mutableIntStateOf(currentYear) }
@@ -187,7 +188,7 @@ fun CalenderView(
                     },
                     monthHeader = { month ->
                         MonthHeader(month)
-                        DaysOfWeekTitle(daysOfWeek)
+                        if (showWeekDaysHeader) DaysOfWeekTitle(daysOfWeek)
                     },
                 )
             }

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -45,10 +46,11 @@ import com.kizitonwose.calendar.core.CalendarDay
 import com.kizitonwose.calendar.core.CalendarMonth
 import com.kizitonwose.calendar.core.DayPosition
 import com.kizitonwose.calendar.core.OutDateStyle
-import com.kizitonwose.calendar.core.firstDayOfWeekFromLocale
+import com.kizitonwose.calendar.core.daysOfWeek
 import rocks.poopjournal.vacationdays.data.VacationData
 import rocks.poopjournal.vacationdays.presentation.ui.theme.MyVacationDays2Theme
 import rocks.poopjournal.vacationdays.presentation.ui.theme.primary
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.Month
 import java.time.YearMonth
@@ -142,11 +144,13 @@ fun CalenderView(
                         }
                     }
                 }
+
+                val daysOfWeek = remember { daysOfWeek() }
                 val state = rememberCalendarState(
                     startMonth = startMonth,
                     endMonth = endMonth,
                     firstVisibleMonth = startMonth,
-                    firstDayOfWeek = firstDayOfWeekFromLocale(),
+                    firstDayOfWeek = daysOfWeek.first(),
                     outDateStyle = OutDateStyle.EndOfRow
                 )
 
@@ -183,6 +187,7 @@ fun CalenderView(
                     },
                     monthHeader = { month ->
                         MonthHeader(month)
+                        DaysOfWeekTitle(daysOfWeek)
                     },
                 )
             }
@@ -266,8 +271,30 @@ fun MonthHeader(calendarMonth: CalendarMonth) {
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.surface,
             )
-            Spacer(modifier = Modifier.height(15.dp))
+            Spacer(modifier = Modifier.height(8.dp))
             Divider()
+        }
+    }
+}
+
+@Composable
+fun DaysOfWeekTitle(daysOfWeek: List<DayOfWeek>) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 8.dp)
+    ) {
+        for (dayOfWeek in daysOfWeek) {
+            Text(
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Center,
+                text = dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
+                style = MaterialTheme.typography.titleSmall,
+                color = when (dayOfWeek) {
+                    DayOfWeek.SATURDAY, DayOfWeek.SUNDAY -> MaterialTheme.colorScheme.surface
+                    else ->  MaterialTheme.colorScheme.onSecondaryContainer
+                },
+            )
         }
     }
 }

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
@@ -232,7 +232,12 @@ private fun Day(
             .aspectRatio(1.2f)
             .background(
                 color = backgroundColor,
-                shape = if (isSelectedStart || isSelectedEnd) CircleShape else RectangleShape
+                shape = when {
+                    (isSelectedStart && selection.endDate == null) -> CircleShape
+                    isSelectedStart -> RoundedCornerShape(50, 0, 0, 50)
+                    isSelectedEnd -> RoundedCornerShape(0, 50, 50, 0)
+                    else -> RectangleShape
+                }
             )
             .clickable(
                 enabled = day.position == DayPosition.MonthDate &&

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/add/AddScreen.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/add/AddScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import rocks.poopjournal.vacationdays.R
 import rocks.poopjournal.vacationdays.data.VacationData
@@ -52,6 +53,8 @@ fun AddScreen(viewModel: AddViewModel = hiltViewModel(), navHostController: NavH
     var endDateString by remember { mutableStateOf("") }
     val emptyVacation = stringResource(R.string.empty_vacation)
     val emptyDate = stringResource(R.string.empty_date)
+
+    val isShowWeekDaysHeader by viewModel.themeSetting.isShowWeekDaysHeaderFlow.collectAsStateWithLifecycle()
 
     Column(modifier = Modifier.fillMaxSize()) {
         TopBar(
@@ -85,7 +88,7 @@ fun AddScreen(viewModel: AddViewModel = hiltViewModel(), navHostController: NavH
             CalenderView(isRangeSelection = true, dateSelected = { startDate, endDate ->
                 startDateString = startDate.format(DateTimeFormatter.ofPattern("d/MM/yyyy"))
                 endDateString = endDate?.format(DateTimeFormatter.ofPattern("d/MM/yyyy")) ?: ""
-            })
+            }, showWeekDaysHeader = isShowWeekDaysHeader)
         }
     }
 

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/add/AddViewModel.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/add/AddViewModel.kt
@@ -13,11 +13,10 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AddViewModel @Inject constructor(
-    private val vacationRepository: VacationRepository
+    private val vacationRepository: VacationRepository,
+    val themeSetting: ThemeSetting
 ) : ViewModel() {
 
-    @Inject
-    lateinit var themeSetting: ThemeSetting
 
     fun addVacation(vacationData: VacationData) {
         if (vacationData.name.isEmpty()) {

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/home/HomeScreen.kt
@@ -83,6 +83,7 @@ fun HomeScreen(viewModel: HomeViewModel = hiltViewModel(), navHostController: Na
     val snackbarHostState = remember { SnackbarHostState() }
 
     val data by viewModel.dataFlow.collectAsStateWithLifecycle(VacData.Empty)
+    val showWeekDateHeader by viewModel.themeSetting.isShowWeekDaysHeaderFlow.collectAsStateWithLifecycle()
 
     val vacation = when (val _data = data) {
         is VacData.Empty -> emptyList()
@@ -150,7 +151,7 @@ fun HomeScreen(viewModel: HomeViewModel = hiltViewModel(), navHostController: Na
                             }
                         })
 
-                    1 -> Calendar(holiday = vacation)
+                    1 -> CalenderView(holidays = vacation, showWeekDaysHeader = showWeekDateHeader)
                 }
             }
         })
@@ -464,12 +465,6 @@ fun TimelineView(vacationList: List<VacationData>, onDelete: (VacationData) -> U
             }
         }
     }
-}
-
-@RequiresApi(Build.VERSION_CODES.O)
-@Composable
-fun Calendar(holiday: List<VacationData>) {
-    CalenderView(isRangeSelection = false, holidays = holiday)
 }
 
 @Composable

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/settings/SettingScreen.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/settings/SettingScreen.kt
@@ -227,7 +227,7 @@ fun SettingScreen(
                 onClick = { viewModel.restoreDatabase() },
                 beforeText = {
                     Icon(
-                        painter = painterResource(id = R.drawable.backup),
+                        painter = painterResource(id = R.drawable.restore),
                         contentDescription = "restore",
                         tint = MaterialTheme.colorScheme.onSecondaryContainer,
                         modifier = Modifier.size(24.dp)

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/settings/SettingScreen.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/settings/SettingScreen.kt
@@ -123,6 +123,7 @@ fun SettingScreen(
 
     var localFeatureEnabled by remember { mutableStateOf(false) }
     var localExcludeWeekendsEnabled by remember { mutableStateOf(false) }
+    val localShowWeekdaysHeaderEnabled by viewModel.themeSetting.isShowWeekDaysHeaderFlow.collectAsState()
 
     LaunchedEffect(localFeatureEnabled) {
         localFeatureEnabled = viewModel.themeSetting.isFeatureEnabled
@@ -167,6 +168,22 @@ fun SettingScreen(
                         localExcludeWeekendsEnabled = newState
 
                         viewModel.themeSetting.isExcludeWeekendsEnabled = newState
+                    },
+                    colors = SwitchDefaults.colors(
+                        checkedIconColor = MaterialTheme.colorScheme.surface,
+                        checkedTrackColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.3f),
+                        checkedThumbColor = MaterialTheme.colorScheme.surface
+                    ),
+                )
+            }
+
+            SettingRow(
+                text = stringResource(id = R.string.show_weekdays_header)
+            ) {
+                Switch(
+                    checked = localShowWeekdaysHeaderEnabled,
+                    onCheckedChange = { newState ->
+                        viewModel.themeSetting.isShowWeekDaysHeaderEnabled = newState
                     },
                     colors = SwitchDefaults.colors(
                         checkedIconColor = MaterialTheme.colorScheme.surface,

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/settings/SettingScreen.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/settings/SettingScreen.kt
@@ -1,7 +1,5 @@
 package rocks.poopjournal.vacationdays.presentation.screen.settings
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -16,7 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -48,7 +46,69 @@ import rocks.poopjournal.vacationdays.presentation.ui.theme.gray
 import rocks.poopjournal.vacationdays.presentation.ui.theme.lightGray
 import java.time.LocalDate
 
-@RequiresApi(Build.VERSION_CODES.O)
+
+@Composable
+fun SectionHeader(text: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = text,
+            color = MaterialTheme.colorScheme.surface,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(start = 16.dp)
+        )
+
+    }
+
+    HorizontalDivider(color = lightGray)
+}
+
+@Composable
+fun SettingRow(text: String, subText: String? = null, beforeText: @Composable (() -> Unit)? = null, onClick: (() -> Unit)? = null, block: @Composable (() -> Unit)? = null) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(64.dp)
+            .padding(start = 16.dp, end = 16.dp)
+            .clickable {
+                onClick?.let { it() }
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column {
+            Row {
+                beforeText?.let {
+                    it()
+                    Spacer(modifier = Modifier.width(16.dp))
+                }
+                Text(
+                    text = text,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+
+            subText?.also {
+                Text(
+                    text = it,
+                    color = gray,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+
+        block?.also {
+            it()
+        }
+    }
+}
+
 @Composable
 fun SettingScreen(
     viewModel: SettingViewModel = hiltViewModel(),
@@ -72,60 +132,17 @@ fun SettingScreen(
     Column(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
         TopBar(onClose = { navHostController.popBackStack() })
         Column {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(48.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = stringResource(id = R.string.general),
-                    color = MaterialTheme.colorScheme.surface,
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(start = 16.dp)
-                )
+            SectionHeader(stringResource(id = R.string.general))
 
-            }
-            HorizontalDivider(color = lightGray)
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(64.dp)
-                    .padding(start = 16.dp)
-                    .clickable { navHostController.navigate(Vacation_Days_Screen) },
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column {
-                    Text(
-                        text = stringResource(id = R.string.noofvacations),
-                        color = MaterialTheme.colorScheme.onSecondaryContainer,
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Bold,
-                    )
-                    Text(
-                        text = vacationNumber.toString(),
-                        color = gray,
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Light,
-                    )
-                }
-            }
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 16.dp)
-                    .height(48.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(id = R.string.track),
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold,
+            SettingRow(
+                text = stringResource(id = R.string.noofvacations),
+                subText = vacationNumber.toString(),
+                onClick = { navHostController.navigate(Vacation_Days_Screen) }
+            )
 
-                    )
-
+            SettingRow(
+                text = stringResource(id = R.string.track)
+            ) {
                 Switch(
                     checked = localFeatureEnabled,
                     onCheckedChange = { newState ->
@@ -140,20 +157,10 @@ fun SettingScreen(
                     ),
                 )
             }
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 16.dp)
-                    .height(48.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(id = R.string.exclude_weekends),
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold,)
 
+            SettingRow(
+                text = stringResource(id = R.string.exclude_weekends)
+            ) {
                 Switch(
                     checked = localExcludeWeekendsEnabled,
                     onCheckedChange = { newState ->
@@ -168,99 +175,48 @@ fun SettingScreen(
                     ),
                 )
             }
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(64.dp)
-                    .padding(start = 16.dp)
-                    .clickable { showDialog = true },
-                verticalAlignment = Alignment.CenterVertically,
-                ) {
-                Column {
-                    Text(
-                        text = stringResource(id = R.string.appearance),
-                        color = MaterialTheme.colorScheme.onSecondaryContainer,
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Bold,
+
+
+            SettingRow(
+                text = stringResource(id = R.string.appearance),
+                subText = stringResource(id = viewModel.themeSetting.theme.getStringResId()),
+                onClick = { showDialog = true }
+            ) {
+                if (showDialog) {
+                    ThemeSelectionDialog(
+                        onDismissRequest = { showDialog = false },
+                        userSetting = viewModel.themeSetting
                     )
-                    Text(
-                        text = stringResource(id = viewModel.themeSetting.theme.getStringResId()),
-                        color = gray,
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Light,
-                    )
-                    if (showDialog) {
-                        ThemeSelectionDialog(
-                            onDismissRequest = { showDialog = false },
-                            userSetting = viewModel.themeSetting
-                        )
-                    }
                 }
             }
+
             Spacer(modifier = Modifier.height(10.dp))
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(48.dp),
-               verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(id = R.string.data),
-                    color = MaterialTheme.colorScheme.surface,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(start = 16.dp)
-                )
-            }
-            HorizontalDivider(color = lightGray)
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(48.dp)
-                    .padding(start = 16.dp)
-                    .clickable {
-                        viewModel.backupDatabase(context.getString(R.string.backupMessage))
-                    },
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.backup),
-                    contentDescription = "Backup",
-                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                    modifier = Modifier.size(24.dp)
-                )
-                Spacer(modifier = Modifier.width(10.dp))
-                Text(
-                    text = stringResource(id = R.string.backupheading),
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold,
-                )
-            }
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(48.dp)
-                    .padding(start = 16.dp)
-                    .clickable {
-                        viewModel.restoreDatabase()
-                    },
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.restore),
-                    contentDescription = "restore",
-                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                    modifier = Modifier.size(24.dp)
-                )
-                Spacer(modifier = Modifier.width(10.dp))
-                Text(
-                    text = stringResource(id = R.string.restore),
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold,
-                )
-            }
+
+            SectionHeader(stringResource(R.string.data))
+            SettingRow(
+                text = stringResource(id = R.string.backupheading),
+                onClick = { viewModel.backupDatabase(context.getString(R.string.backupMessage)) },
+                beforeText = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.backup),
+                        contentDescription = "Backup",
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            )
+            SettingRow(
+                text = stringResource(id = R.string.restore),
+                onClick = { viewModel.restoreDatabase() },
+                beforeText = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.backup),
+                        contentDescription = "restore",
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            )
         }
     }
 }
@@ -284,7 +240,7 @@ private fun TopBar(onClose: () -> Unit) {
                 modifier = Modifier.align(Alignment.CenterStart)
             ) {
                 Icon(
-                    imageVector = Icons.Rounded.ArrowBack,
+                    imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
                     contentDescription = "Back",
                     tint = Color.White
                 )

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/ui/utils/ThemeModes.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/ui/utils/ThemeModes.kt
@@ -27,4 +27,6 @@ interface ThemeSetting {
     var isFeatureEnabled: Boolean
     var isExcludeWeekendsEnabled: Boolean
     val isExcludeWeekendsFlow: StateFlow<Boolean>
+    var isShowWeekDaysHeaderEnabled: Boolean
+    val isShowWeekDaysHeaderFlow: StateFlow<Boolean>
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="empty_text">No Vacation Added</string>
     <string name="track">Track Sick Days</string>
     <string name="exclude_weekends">Exclude weekends</string>
+    <string name="show_weekdays_header">Show weekdays header</string>
     <string name="backupMessage">Backup Successful</string>
     <string name="vacation_days">No. of Vacation Days</string>
     <string name="junit">JUnit</string>


### PR DESCRIPTION
This PR contains:
- fix for #234 via refactoring of Settings screen. Rows are now bundled as `SectionHeader` and `SettingRow`'s making `SettingScreen` way more readable and uniform. Also I've altered typography styles to make the page bit easier on the eyes
- fix for #267 by adding a row with days of the week to the calendar. Saturdays and Sundays are slightly "highlighted"
- style improvement for calendar selection boundries

Check attached screenshots:
<p align="center" float="left">
<img src="https://github.com/user-attachments/assets/735650d6-d11b-4898-a34c-cefa4b1c2b0b" width="150px"/>
<img alt="day of the week row" src="https://github.com/user-attachments/assets/78c8765c-c510-4c25-96d1-42f9ed2b2a7f" width="150px"/>
<img alt="calendar selection style" src="https://github.com/user-attachments/assets/72052dea-f616-4386-a818-880ef401fae7" width="150px"/>
</p>
