### PR TITLE
Calendar design closer to mockup + autoscroll to current month

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,10 +47,11 @@ android {
         }
     }
 
-testOptions {
+    testOptions {
         unitTests.all {
             jacoco {
                 includeNoLocationClasses = true
+                excludes = ['jdk.internal.*']
             }
         }
         unitTests.returnDefaultValues = true

--- a/app/src/main/java/rocks/poopjournal/vacationdays/di/CoroutinesScopesModule.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/di/CoroutinesScopesModule.kt
@@ -1,0 +1,19 @@
+package rocks.poopjournal.vacationdays.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+object CoroutinesScopesModule {
+
+    @Singleton
+    @Provides
+    fun providesCoroutineScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+}

--- a/app/src/main/java/rocks/poopjournal/vacationdays/di/UseCaseModule.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/di/UseCaseModule.kt
@@ -1,0 +1,30 @@
+package rocks.poopjournal.vacationdays.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import rocks.poopjournal.vacationdays.domain.repo.VacationNumberRepository
+import rocks.poopjournal.vacationdays.domain.repo.VacationRepository
+import rocks.poopjournal.vacationdays.presentation.ui.utils.ThemeSetting
+import rocks.poopjournal.vacationdays.presentation.usecase.VacationDataUseCase
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+object UseCaseModule {
+
+    @Singleton
+    @Provides
+    fun providesVacationDataUseCase(
+        scope: CoroutineScope, vacationRepository: VacationRepository,
+        vacationNumberRepository: VacationNumberRepository,
+        themeSetting: ThemeSetting
+    ): VacationDataUseCase = VacationDataUseCase(
+        scope,
+        vacationRepository,
+        vacationNumberRepository,
+        themeSetting
+    )
+}

--- a/app/src/main/java/rocks/poopjournal/vacationdays/domain/model/daysCalculator.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/domain/model/daysCalculator.kt
@@ -1,0 +1,40 @@
+package rocks.poopjournal.vacationdays.domain.model
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+private fun DayOfWeek.isWeekend() = (this == DayOfWeek.SATURDAY) || (this == DayOfWeek.SUNDAY)
+
+fun calculateDaysBetween(
+    startDate: LocalDate,
+    endDate: LocalDate?,
+    excludeWeekends: Boolean = false
+): Int {
+    return if (endDate == null) {
+        if (excludeWeekends && startDate.dayOfWeek.isWeekend()) 0 else 1 // If no end date, count it as 1 day
+    } else {
+        val days = ChronoUnit.DAYS.between(startDate, endDate).toInt() + 1
+
+        if (!excludeWeekends) {
+            return days
+        }
+
+        // Calculate number of complete weeks
+        val fullWeeks = days / 7
+        var weekendDays = fullWeeks * 2
+
+        // Handle remaining days after full weeks
+        val remainingDays = days % 7
+        val startDayOfWeek = startDate.dayOfWeek.value
+
+        for (i in 0 until remainingDays) {
+            val dayOfWeek = (startDayOfWeek + i - 1) % 7 + 1
+            if (dayOfWeek == DayOfWeek.SATURDAY.value || dayOfWeek == DayOfWeek.SUNDAY.value) {
+                weekendDays++
+            }
+        }
+
+        return days - weekendDays
+    }
+}

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
@@ -235,6 +235,7 @@ private fun Day(
 
     val textColor = when {
         isRangeSelection && (isSelectedStart || isSelectedEnd) -> MaterialTheme.colorScheme.onSecondaryContainer // Ensure contrast when selected
+        isRangeSelection && isHoliday(day.date, holidays) ->  MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha=0.4f)
         day.date == today -> MaterialTheme.colorScheme.surface // Highlight today's date with Surface color
         else -> MaterialTheme.colorScheme.onSecondaryContainer
     }

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
@@ -15,11 +15,14 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -36,6 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -47,6 +51,7 @@ import com.kizitonwose.calendar.core.CalendarMonth
 import com.kizitonwose.calendar.core.DayPosition
 import com.kizitonwose.calendar.core.OutDateStyle
 import com.kizitonwose.calendar.core.daysOfWeek
+import rocks.poopjournal.vacationdays.R
 import rocks.poopjournal.vacationdays.data.VacationData
 import rocks.poopjournal.vacationdays.presentation.ui.theme.MyVacationDays2Theme
 import rocks.poopjournal.vacationdays.presentation.ui.theme.primary
@@ -234,14 +239,7 @@ private fun Day(
     }
     Box(
         modifier = Modifier
-            .aspectRatio(1.2f)
-            .background(
-                color = backgroundColor,
-                shape = when {
-                    isSelectedStart || isSelectedEnd -> CircleShape
-                    else -> RectangleShape
-                }
-            )
+            .aspectRatio(1f)
             .clickable(
                 enabled = day.position == DayPosition.MonthDate &&
                         day.date.isAfter(today.minusYears(30)),
@@ -249,29 +247,58 @@ private fun Day(
             ),
         contentAlignment = Alignment.Center,
     ) {
-        Box (
-            modifier = Modifier
-                .background(color = secondaryBackgroundColor,
-                    shape= when {
-                        (isSelectedStart && selection.endDate == null) -> CircleShape
-                        isSelectedStart -> RoundedCornerShape(50, 0, 0, 50)
-                        isSelectedEnd -> RoundedCornerShape(0, 50, 50, 0)
-                        else -> RectangleShape
-                    })
-                .matchParentSize(),
-            contentAlignment = Alignment.Center,
-        ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(
-                    text = day.date.dayOfMonth.toString(),
-                    color = textColor,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold,
-                )
-                if (!isRangeSelection) {
-                    Text(text = ".", fontWeight = FontWeight.Bold, color = dotColor)
+
+        // selection range box
+        Box(modifier = Modifier
+            .matchParentSize()
+            .let {
+                when {
+                    (isSelectedStart && selection.endDate == null) -> it.padding(8.dp)
+                    isSelectedStart -> it.padding(start = 8.dp, top = 8.dp, bottom = 8.dp)
+                    isSelectedEnd -> it.padding(end = 8.dp, top = 8.dp, bottom = 8.dp)
+                    isInRange -> it.padding(vertical = 8.dp)
+                    else -> it
                 }
             }
+            .background(
+                color = secondaryBackgroundColor,
+                shape = when {
+                    (isSelectedStart && selection.endDate == null) -> CircleShape
+                    isSelectedStart -> RoundedCornerShape(50, 0, 0, 50)
+                    isSelectedEnd -> RoundedCornerShape(0, 50, 50, 0)
+                    else -> RectangleShape
+                }
+            )
+        )
+
+        // current select box
+        Box(modifier = Modifier
+            .matchParentSize()
+            .padding(8.dp)
+            .background(
+                color = backgroundColor,
+                shape = when {
+                    isSelectedStart || isSelectedEnd -> CircleShape
+                    else -> RectangleShape
+                }
+            ),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = day.date.dayOfMonth.toString(),
+                color = textColor,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+
+        if (!isRangeSelection) {
+            Icon(
+                modifier = Modifier.offset(y = 16.dp),
+                contentDescription = null,
+                painter = painterResource(R.drawable.dot),
+                tint = dotColor
+            )
         }
     }
 }

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/component/CustomCalender.kt
@@ -51,6 +51,7 @@ import com.kizitonwose.calendar.core.CalendarMonth
 import com.kizitonwose.calendar.core.DayPosition
 import com.kizitonwose.calendar.core.OutDateStyle
 import com.kizitonwose.calendar.core.daysOfWeek
+import com.kizitonwose.calendar.core.yearMonth
 import rocks.poopjournal.vacationdays.R
 import rocks.poopjournal.vacationdays.data.VacationData
 import rocks.poopjournal.vacationdays.presentation.ui.theme.MyVacationDays2Theme
@@ -70,21 +71,26 @@ import java.util.Locale
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun CalenderView(
+    focusOnDate: LocalDate? = null,
     dateSelected: (startDate: LocalDate, endDate: LocalDate?) -> Unit = { _, _ -> },
     isRangeSelection: Boolean = false,
     holidays: List<VacationData> = emptyList(),
     showWeekDaysHeader: Boolean = false,
 ) {
-    val currentYear = YearMonth.now().year
-    var selectedYear by remember { mutableIntStateOf(currentYear) }
+    var selectedYear by remember {
+        mutableIntStateOf(focusOnDate
+            ?.year
+            ?: YearMonth.now().year
+        )
+    }
+    val today = remember { LocalDate.now() }
 
     val startMonth = remember(selectedYear) { YearMonth.of(selectedYear, 1) }
     val endMonth = remember(selectedYear) { YearMonth.of(selectedYear, 12) }
 
-    val today = remember { LocalDate.now() }
     var selection by remember { mutableStateOf(DateSelection()) }
 
-    val years = (currentYear - 30..currentYear + 30).toList()
+    val years = (selectedYear - 30..selectedYear + 30).toList()
     var expanded by remember { mutableStateOf(false) }
 
     MaterialTheme(colorScheme = MaterialTheme.colorScheme.copy(primary = primary)) {
@@ -135,6 +141,7 @@ fun CalenderView(
                         ) {
                             years.forEach { year ->
                                 DropdownMenuItem(
+                                    enabled = year != selectedYear,
                                     text = {
                                         Text(
                                             year.toString(),
@@ -155,7 +162,7 @@ fun CalenderView(
                 val state = rememberCalendarState(
                     startMonth = startMonth,
                     endMonth = endMonth,
-                    firstVisibleMonth = startMonth,
+                    firstVisibleMonth = focusOnDate?.yearMonth ?: startMonth,
                     firstDayOfWeek = daysOfWeek.first(),
                     outDateStyle = OutDateStyle.EndOfRow
                 )

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/add/AddScreen.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/add/AddScreen.kt
@@ -39,6 +39,7 @@ import rocks.poopjournal.vacationdays.R
 import rocks.poopjournal.vacationdays.data.VacationData
 import rocks.poopjournal.vacationdays.presentation.component.CalenderView
 import rocks.poopjournal.vacationdays.presentation.component.CustomTab
+import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -88,7 +89,7 @@ fun AddScreen(viewModel: AddViewModel = hiltViewModel(), navHostController: NavH
             CalenderView(isRangeSelection = true, dateSelected = { startDate, endDate ->
                 startDateString = startDate.format(DateTimeFormatter.ofPattern("d/MM/yyyy"))
                 endDateString = endDate?.format(DateTimeFormatter.ofPattern("d/MM/yyyy")) ?: ""
-            }, showWeekDaysHeader = isShowWeekDaysHeader)
+            }, showWeekDaysHeader = isShowWeekDaysHeader, focusOnDate = LocalDate.now())
         }
     }
 

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/add/AddScreen.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/add/AddScreen.kt
@@ -37,6 +37,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import rocks.poopjournal.vacationdays.R
 import rocks.poopjournal.vacationdays.data.VacationData
+import rocks.poopjournal.vacationdays.domain.model.VacData
 import rocks.poopjournal.vacationdays.presentation.component.CalenderView
 import rocks.poopjournal.vacationdays.presentation.component.CustomTab
 import java.time.LocalDate
@@ -48,6 +49,8 @@ fun AddScreen(viewModel: AddViewModel = hiltViewModel(), navHostController: NavH
 
     var selectedTab by remember { mutableIntStateOf(1) }
     val context = LocalContext.current
+
+    val data by viewModel.vacationsUseCase.vacationsFlow.collectAsStateWithLifecycle(VacData.Empty)
 
     var vacationName by remember { mutableStateOf("") }
     var startDateString by remember { mutableStateOf("") }
@@ -86,10 +89,19 @@ fun AddScreen(viewModel: AddViewModel = hiltViewModel(), navHostController: NavH
         )
 
         Column(modifier = Modifier.fillMaxWidth()) {
-            CalenderView(isRangeSelection = true, dateSelected = { startDate, endDate ->
-                startDateString = startDate.format(DateTimeFormatter.ofPattern("d/MM/yyyy"))
-                endDateString = endDate?.format(DateTimeFormatter.ofPattern("d/MM/yyyy")) ?: ""
-            }, showWeekDaysHeader = isShowWeekDaysHeader, focusOnDate = LocalDate.now())
+            CalenderView(
+                holidays = when (val _data = data) {
+                    is VacData.Empty -> emptyList()
+                    is VacData.Success -> _data.vacations
+                },
+                isRangeSelection = true,
+                dateSelected = { startDate, endDate ->
+                    startDateString = startDate.format(DateTimeFormatter.ofPattern("d/MM/yyyy"))
+                    endDateString = endDate?.format(DateTimeFormatter.ofPattern("d/MM/yyyy")) ?: ""
+                },
+                showWeekDaysHeader = isShowWeekDaysHeader,
+                focusOnDate = LocalDate.now()
+            )
         }
     }
 

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/add/AddViewModel.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/add/AddViewModel.kt
@@ -1,7 +1,5 @@
 package rocks.poopjournal.vacationdays.presentation.screen.add
 
-import android.content.Context
-import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -9,12 +7,14 @@ import kotlinx.coroutines.launch
 import rocks.poopjournal.vacationdays.data.VacationData
 import rocks.poopjournal.vacationdays.domain.repo.VacationRepository
 import rocks.poopjournal.vacationdays.presentation.ui.utils.ThemeSetting
+import rocks.poopjournal.vacationdays.presentation.usecase.VacationDataUseCase
 import javax.inject.Inject
 
 @HiltViewModel
 class AddViewModel @Inject constructor(
     private val vacationRepository: VacationRepository,
-    val themeSetting: ThemeSetting
+    val themeSetting: ThemeSetting,
+    val vacationsUseCase: VacationDataUseCase,
 ) : ViewModel() {
 
 

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/home/HomeScreen.kt
@@ -82,7 +82,7 @@ fun HomeScreen(viewModel: HomeViewModel = hiltViewModel(), navHostController: Na
     val (selectedTab, setSelectedTab) = remember { mutableIntStateOf(0) }
     val snackbarHostState = remember { SnackbarHostState() }
 
-    val data by viewModel.dataFlow.collectAsStateWithLifecycle(VacData.Empty)
+    val data by viewModel.vacationsUseCase.vacationsFlow.collectAsStateWithLifecycle(VacData.Empty)
     val showWeekDateHeader by viewModel.themeSetting.isShowWeekDaysHeaderFlow.collectAsStateWithLifecycle()
 
     val vacation = when (val _data = data) {

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/home/HomeScreen.kt
@@ -151,7 +151,11 @@ fun HomeScreen(viewModel: HomeViewModel = hiltViewModel(), navHostController: Na
                             }
                         })
 
-                    1 -> CalenderView(holidays = vacation, showWeekDaysHeader = showWeekDateHeader)
+                    1 -> CalenderView(
+                        holidays = vacation,
+                        showWeekDaysHeader = showWeekDateHeader,
+                        focusOnDate = LocalDate.now()
+                    )
                 }
             }
         })

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/screen/home/HomeViewModel.kt
@@ -3,91 +3,20 @@ package rocks.poopjournal.vacationdays.presentation.screen.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import rocks.poopjournal.vacationdays.data.VacationData
-import rocks.poopjournal.vacationdays.domain.model.VacData
-import rocks.poopjournal.vacationdays.domain.repo.VacationNumberRepository
 import rocks.poopjournal.vacationdays.domain.repo.VacationRepository
 import rocks.poopjournal.vacationdays.presentation.ui.utils.ThemeSetting
-import java.time.DayOfWeek
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
+import rocks.poopjournal.vacationdays.presentation.usecase.VacationDataUseCase
 import javax.inject.Inject
 
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val vacationRepository: VacationRepository,
-    private val vacationNumberRepository: VacationNumberRepository,
-    val themeSetting: ThemeSetting
+    val themeSetting: ThemeSetting,
+    val vacationsUseCase: VacationDataUseCase,
 ) : ViewModel() {
-
-    private val formatter = DateTimeFormatter.ofPattern("d/MM/yyyy") // Match the saved format
-
-    val dataFlow: SharedFlow<VacData> =
-        combine(
-            vacationRepository.getAllData(),
-            themeSetting.isExcludeWeekendsFlow,
-        ) { data, isExcludeHolidays ->
-
-            val vacationDaysCount = data
-                .filter { it.category == "Vacation" }
-                .sumOf { calculateDaysBetween(it.startDate, it.endDate, isExcludeHolidays) }
-
-            val sickDaysCount = data
-                .filter { it.category == "Sick" }
-                .sumOf { calculateDaysBetween(it.startDate, it.endDate, isExcludeHolidays) }
-
-            val currentYear = LocalDate.now().year.toString()
-            val vacationNumber = vacationNumberRepository.getVacationNumberForYear(currentYear)
-            val maxVacationNumber = maxOf(vacationNumber - vacationDaysCount, 0)
-
-            VacData.Success(
-                vacations = data.sortedBy { LocalDate.parse(it.startDate, formatter) },
-                vacationDays = vacationDaysCount,
-                sickDays = sickDaysCount,
-                vacationsNumber = maxVacationNumber
-            )
-        }
-            .stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5000),
-                initialValue = VacData.Empty
-            )
-
-
-    private fun calculateDaysBetween(
-        startDate: String,
-        endDate: String?,
-        excludeWeekends: Boolean = false
-    ): Int {
-        val start = LocalDate.parse(startDate, formatter)
-
-        return if (endDate.isNullOrEmpty()) {
-            1 // If no end date, count it as 1 day
-        } else {
-            val end = LocalDate.parse(endDate, formatter)
-            val days = ChronoUnit.DAYS.between(start, end).toInt()
-
-            if (excludeWeekends) {
-                val startW = start.dayOfWeek
-                val endW = end.dayOfWeek
-                val daysWithoutWeekends = days - 2 * ((days + startW.value) / 7)
-
-                (daysWithoutWeekends
-                        + (if (startW == DayOfWeek.SUNDAY) 1 else 0)
-                        + (if (endW == DayOfWeek.SUNDAY) 1 else 0)
-                        + 1 // include start and end
-                        )
-            } else
-                days + 1 // Include both start and end
-        }
-    }
 
     fun deleteVacation(vacationData: VacationData) {
         viewModelScope.launch {

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/usecase/VacationDataUseCase.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/usecase/VacationDataUseCase.kt
@@ -1,0 +1,87 @@
+package rocks.poopjournal.vacationdays.presentation.usecase
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import rocks.poopjournal.vacationdays.domain.model.VacData
+import rocks.poopjournal.vacationdays.domain.repo.VacationNumberRepository
+import rocks.poopjournal.vacationdays.domain.repo.VacationRepository
+import rocks.poopjournal.vacationdays.presentation.ui.utils.ThemeSetting
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class VacationDataUseCase @Inject constructor (
+    scope: CoroutineScope,
+    vacationRepository: VacationRepository,
+    vacationNumberRepository: VacationNumberRepository,
+    themeSetting: ThemeSetting
+) {
+    private val formatter = DateTimeFormatter.ofPattern("d/MM/yyyy") // Match the saved format
+
+    val vacationsFlow: SharedFlow<VacData> =
+        combine(
+            vacationRepository.getAllData(),
+            themeSetting.isExcludeWeekendsFlow,
+        ) { data, isExcludeHolidays ->
+
+            val vacationDaysCount = data
+                .filter { it.category == "Vacation" }
+                .sumOf { calculateDaysBetween(it.startDate, it.endDate, isExcludeHolidays) }
+
+            val sickDaysCount = data
+                .filter { it.category == "Sick" }
+                .sumOf { calculateDaysBetween(it.startDate, it.endDate, isExcludeHolidays) }
+
+            val currentYear = LocalDate.now().year.toString()
+            val vacationNumber = vacationNumberRepository.getVacationNumberForYear(currentYear)
+            val maxVacationNumber = maxOf(vacationNumber - vacationDaysCount, 0)
+
+            VacData.Success(
+                vacations = data.sortedBy { LocalDate.parse(it.startDate, formatter) },
+                vacationDays = vacationDaysCount,
+                sickDays = sickDaysCount,
+                vacationsNumber = maxVacationNumber
+            )
+        }
+            .stateIn(
+                scope = scope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = VacData.Empty
+            )
+
+
+    private fun calculateDaysBetween(
+        startDate: String,
+        endDate: String?,
+        excludeWeekends: Boolean = false
+    ): Int {
+        val start = LocalDate.parse(startDate, formatter)
+
+        return if (endDate.isNullOrEmpty()) {
+            1 // If no end date, count it as 1 day
+        } else {
+            val end = LocalDate.parse(endDate, formatter)
+            val days = ChronoUnit.DAYS.between(start, end).toInt()
+
+            if (excludeWeekends) {
+                val startW = start.dayOfWeek
+                val endW = end.dayOfWeek
+                val daysWithoutWeekends = days - 2 * ((days + startW.value) / 7)
+
+                (daysWithoutWeekends
+                        + (if (startW == DayOfWeek.SUNDAY) 1 else 0)
+                        + (if (endW == DayOfWeek.SUNDAY) 1 else 0)
+                        + 1 // include start and end
+                        )
+            } else
+                days + 1 // Include both start and end
+        }
+    }
+}

--- a/app/src/main/java/rocks/poopjournal/vacationdays/presentation/usecase/VacationDataUseCase.kt
+++ b/app/src/main/java/rocks/poopjournal/vacationdays/presentation/usecase/VacationDataUseCase.kt
@@ -5,25 +5,31 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import rocks.poopjournal.vacationdays.data.VacationData
 import rocks.poopjournal.vacationdays.domain.model.VacData
+import rocks.poopjournal.vacationdays.domain.model.calculateDaysBetween
 import rocks.poopjournal.vacationdays.domain.repo.VacationNumberRepository
 import rocks.poopjournal.vacationdays.domain.repo.VacationRepository
 import rocks.poopjournal.vacationdays.presentation.ui.utils.ThemeSetting
-import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class VacationDataUseCase @Inject constructor (
+class VacationDataUseCase @Inject constructor(
     scope: CoroutineScope,
     vacationRepository: VacationRepository,
     vacationNumberRepository: VacationNumberRepository,
     themeSetting: ThemeSetting
 ) {
     private val formatter = DateTimeFormatter.ofPattern("d/MM/yyyy") // Match the saved format
+
+    private fun VacationData.parsedDates(): Pair<LocalDate, LocalDate?> {
+        val start = LocalDate.parse(startDate, formatter)
+        val end = endDate?.let { LocalDate.parse(it, formatter) }
+        return start to end
+    }
 
     val vacationsFlow: SharedFlow<VacData> =
         combine(
@@ -33,11 +39,17 @@ class VacationDataUseCase @Inject constructor (
 
             val vacationDaysCount = data
                 .filter { it.category == "Vacation" }
-                .sumOf { calculateDaysBetween(it.startDate, it.endDate, isExcludeHolidays) }
+                .sumOf {
+                    val (start, end) = it.parsedDates()
+                    calculateDaysBetween(start, end, isExcludeHolidays)
+                }
 
             val sickDaysCount = data
                 .filter { it.category == "Sick" }
-                .sumOf { calculateDaysBetween(it.startDate, it.endDate, isExcludeHolidays) }
+                .sumOf {
+                    val (start, end) = it.parsedDates()
+                    calculateDaysBetween(start, end, isExcludeHolidays)
+                }
 
             val currentYear = LocalDate.now().year.toString()
             val vacationNumber = vacationNumberRepository.getVacationNumberForYear(currentYear)
@@ -55,33 +67,4 @@ class VacationDataUseCase @Inject constructor (
                 started = SharingStarted.WhileSubscribed(5000),
                 initialValue = VacData.Empty
             )
-
-
-    private fun calculateDaysBetween(
-        startDate: String,
-        endDate: String?,
-        excludeWeekends: Boolean = false
-    ): Int {
-        val start = LocalDate.parse(startDate, formatter)
-
-        return if (endDate.isNullOrEmpty()) {
-            1 // If no end date, count it as 1 day
-        } else {
-            val end = LocalDate.parse(endDate, formatter)
-            val days = ChronoUnit.DAYS.between(start, end).toInt()
-
-            if (excludeWeekends) {
-                val startW = start.dayOfWeek
-                val endW = end.dayOfWeek
-                val daysWithoutWeekends = days - 2 * ((days + startW.value) / 7)
-
-                (daysWithoutWeekends
-                        + (if (startW == DayOfWeek.SUNDAY) 1 else 0)
-                        + (if (endW == DayOfWeek.SUNDAY) 1 else 0)
-                        + 1 // include start and end
-                        )
-            } else
-                days + 1 // Include both start and end
-        }
-    }
 }

--- a/app/src/main/res/drawable/dot.xml
+++ b/app/src/main/res/drawable/dot.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="4dp"
+    android:height="4dp"
+    android:viewportWidth="4"
+    android:viewportHeight="4">
+    <path
+        android:pathData="M2,2H2"
+        android:strokeLineJoin="round"
+        android:strokeWidth="4"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+</vector>

--- a/app/src/test/java/rocks/poopjournal/vacationdays/domain/model/DaysCalculatorTest.kt
+++ b/app/src/test/java/rocks/poopjournal/vacationdays/domain/model/DaysCalculatorTest.kt
@@ -1,0 +1,62 @@
+package rocks.poopjournal.vacationdays.domain.model
+
+import org.junit.Test
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+
+class DaysCalculatorTest {
+    private val formatter = DateTimeFormatter.ofPattern("d/MM/yyyy") // Match the saved format
+
+    private fun String.toLocalDate() = LocalDate.parse(this, formatter)
+
+    private fun diffAssert(value : Int, expected: Int) {
+        assert(value == expected) { "$value != $expected" }
+    }
+
+    @Test
+    fun `sun to sat with weekends is 7 days`() {
+
+        diffAssert(calculateDaysBetween(
+            "04/05/2025".toLocalDate(),
+            "10/05/2025".toLocalDate(),
+            excludeWeekends = false,
+        ), 7)
+    }
+
+    @Test
+    fun `sun to sat without weekends is 5 days`() {
+        diffAssert(calculateDaysBetween(
+            "04/05/2025".toLocalDate(),
+            "10/05/2025".toLocalDate(),
+            excludeWeekends = true,
+        ), 5)
+    }
+
+    @Test
+    fun `mon to fri without weekends is 5 days`() {
+        diffAssert(calculateDaysBetween(
+            "05/05/2025".toLocalDate(),
+            "09/05/2025".toLocalDate(),
+            excludeWeekends = true,
+        ), 5)
+    }
+
+    @Test
+    fun `mon to next fri without weekends is 10 days`() {
+        diffAssert(calculateDaysBetween(
+            "05/05/2025".toLocalDate(),
+            "16/05/2025".toLocalDate(),
+            excludeWeekends = true,
+        ), 10)
+    }
+
+    @Test
+    fun `mon to next fri with weekends is 14 days`() {
+        diffAssert(calculateDaysBetween(
+            "05/05/2025".toLocalDate(),
+            "16/05/2025".toLocalDate(),
+            excludeWeekends = false,
+        ), 12)
+    }
+}


### PR DESCRIPTION
Hello again! 

In this PR:
- (visual) truly round days in calendar with proper range selector
- (visual) more noticeable "dot" indicator
- (visual) show vacations days on "Add" screen
- (code) refactored vacation data flow into reusable shared usecase (`VacationDataUseCase`)
- (behaviour) calendar component can now focus on given date. by default it's `now()` which makes life easier by having to scroll less every time you change screens

<p align="center">
<img src="https://github.com/user-attachments/assets/978f3695-7f32-4c31-985f-7c93ecc4051c" width="150px"/>
<img src="https://github.com/user-attachments/assets/82041bb0-5b6e-46ff-b7de-a2939c19137b" width="150px"/>
<img src="https://github.com/user-attachments/assets/2951bc37-f361-4312-a529-5f50c2bd5876" width="150px"/>
</p>